### PR TITLE
Update manifest.json

### DIFF
--- a/tapo_p100_control/manifest.json
+++ b/tapo_p100_control/manifest.json
@@ -5,5 +5,6 @@
   "issue_tracker": "https://github.com/fishbigger/HomeAssistant-Tapo-P100-Control/issues",
   "dependencies": [],
   "codeowners": ["@fishbigger", "@K4CZP3R"],
-  "requirements": ["PyP100==0.0.11"]
+  "requirements": ["PyP100==0.0.11"],
+  "version": "0.0.0"
 }


### PR DESCRIPTION
As detailed in [here](https://www.home-assistant.io/blog/2021/03/03/release-20213/#read-more), a version number will be required in the future for custom components. There is a flurry of others that need this when looking on [Google](https://www.google.co.uk/search?q=ha+version+manifest).