### PR TITLE
Handshake removed during status change

### DIFF
--- a/tapo_p100_control/light.py
+++ b/tapo_p100_control/light.py
@@ -75,8 +75,6 @@ class L1510Bulb(LightEntity):
 
     def turn_on(self, **kwargs) -> None:
         """Turn Plug On"""
-        self._p100.handshake()
-        self._p100.login()
 
         newBrightness = kwargs.get(ATTR_BRIGHTNESS, 255)
 
@@ -90,8 +88,6 @@ class L1510Bulb(LightEntity):
 
     def turn_off(self, **kwargs):
         """Turn Plug Off"""
-        self._p100.handshake()
-        self._p100.login()
         self._p100.turnOff()
 
         self._is_on = False

--- a/tapo_p100_control/switch.py
+++ b/tapo_p100_control/switch.py
@@ -63,8 +63,6 @@ class P100Plug(SwitchEntity):
 
     def turn_on(self, **kwargs) -> None:
         """Turn Plug On"""
-        self._p100.handshake()
-        self._p100.login()
 
         self._p100.turnOn()
 
@@ -72,8 +70,7 @@ class P100Plug(SwitchEntity):
 
     def turn_off(self, **kwargs):
         """Turn Plug Off"""
-        self._p100.handshake()
-        self._p100.login()
+        
         self._p100.turnOff()
 
         self._is_on = False


### PR DESCRIPTION
As suggested in #12 handshake during light/switch status change has been removed.

Seems to be working so far, about one month of debugging, but might wanna merge into a dev branch for further testing.