### PR TITLE
Mapped the device MAC to unique_id to allow entity registry

### DIFF
--- a/tapo_p100_control/light.py
+++ b/tapo_p100_control/light.py
@@ -13,6 +13,7 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS
     )
 from homeassistant.const import CONF_IP_ADDRESS, CONF_EMAIL, CONF_PASSWORD
+from homeassistant.helpers.device_registry import format_mac
 
 import json
 
@@ -60,6 +61,11 @@ class L1510Bulb(LightEntity):
         return self._name
 
     @property
+    def unique_id(self):
+        """Unique ID of the device. Uses device MAC."""
+        return self._mac
+
+    @property
     def is_on(self):
         """Name of the device."""
         return self._is_on
@@ -101,8 +107,9 @@ class L1510Bulb(LightEntity):
         self._p100.login()
 
         self._name = self._p100.getDeviceName()
- 
+
         data = json.loads(self._p100.getDeviceInfo())
 
         self._is_on = data["result"]["device_on"]
         self._brightness = data["result"]["brightness"]
+        self._mac = format_mac(data["result"]["mac"])

--- a/tapo_p100_control/switch.py
+++ b/tapo_p100_control/switch.py
@@ -11,6 +11,7 @@ from homeassistant.components.switch import (
     PLATFORM_SCHEMA,
     )
 from homeassistant.const import CONF_IP_ADDRESS, CONF_EMAIL, CONF_PASSWORD
+from homeassistant.helpers.device_registry import format_mac
 
 import json
 
@@ -57,6 +58,11 @@ class P100Plug(SwitchEntity):
         return self._name
 
     @property
+    def unique_id(self):
+        """Unique ID of the device. Uses device MAC."""
+        return self._mac
+
+    @property
     def is_on(self):
         """Name of the device."""
         return self._is_on
@@ -83,7 +89,8 @@ class P100Plug(SwitchEntity):
         self._p100.login()
 
         self._name = self._p100.getDeviceName()
- 
+
         data = json.loads(self._p100.getDeviceInfo())
 
         self._is_on = data["result"]["device_on"]
+        self._mac = format_mac(data["result"]["mac"])


### PR DESCRIPTION
I have a few lights and switches that I'd like to be placed in different areas, but Home Assistant requires a unique_id. Details here: https://developers.home-assistant.io/docs/entity_registry_index/

After some digging around it seems like the device info dict contains the device MAC, so I've added it in. Tested and works with my L510E and P100.