### PR TITLE
Fix brightness calculation and jumping

### DIFF
--- a/tapo_p100_control/light.py
+++ b/tapo_p100_control/light.py
@@ -84,13 +84,11 @@ class L1510Bulb(LightEntity):
 
         newBrightness = kwargs.get(ATTR_BRIGHTNESS, 255)
 
-        newBrightness = (newBrightness / 255) * 100
-
-        self._l530.setBrightness(newBrightness)
+        self._l530.setBrightness(round(newBrightness / 255 * 100))
         self._l530.turnOn()
 
         self._is_on = True
-        self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        self._brightness = newBrightness
 
     def turn_off(self, **kwargs):
         """Turn Plug Off"""
@@ -110,4 +108,4 @@ class L1510Bulb(LightEntity):
 
         self._is_on = data["result"]["device_on"]
         self._unique_id = data["result"]["device_id"]
-        self._brightness = data["result"]["brightness"]
+        self._brightness = round(data["result"]["brightness"] * 255 / 100)


### PR DESCRIPTION
I've added my light bulb L510 to homeassistant and after changing the brightness the slider jumps back to a different value. After some debugging I found that the calculation is off and the value needs to be rounded. 

I thought it is a issue on the P100 lib (https://github.com/fishbigger/TapoP100/issues/46) but this change fixed it. 