### PR TITLE
error on second handshake

### DIFF
--- a/tapo_p100_control/switch.py
+++ b/tapo_p100_control/switch.py
@@ -10,7 +10,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.switch import (
     SwitchEntity,
     PLATFORM_SCHEMA,
-    )
+)
 from homeassistant.const import CONF_IP_ADDRESS, CONF_EMAIL, CONF_PASSWORD
 
 import json
@@ -23,6 +23,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 _LOGGER = logging.getLogger(__name__)
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Awesome Light platform."""
@@ -42,6 +43,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _LOGGER.error("Could not connect to plug. Possibly invalid credentials")
 
     add_entities([P100Plug(p100)])
+
 
 class P100Plug(SwitchEntity):
     """Representation of a P100 Plug"""
@@ -80,8 +82,15 @@ class P100Plug(SwitchEntity):
         self._is_on = False
 
     def update(self):
-        self._p100.handshake()
-        self._p100.login()
+        try:
+            self._p100.handshake()
+        except Exception as e:
+            _LOGGER.error("UPDATE:handshake error: {}".format(str(e)))
+
+        try:
+            self._p100.login()
+        except Exception as e:
+            _LOGGER.error("UPDATE:login error: {}".format(str(e)))
 
         data = self._p100.getDeviceInfo()
 


### PR DESCRIPTION
recently,, i've updated HA to 2022.4 version; with the upgrade, the HomeAssistant-Tapo-P100-Control integration stopped working, so i updated everything (the integration, the PyP100 library) in order to get it working again

i've managed to get the plugs recognized at start (the setup_platform method goes ok with my 4 switches), but, when HA invokes the update method of each one, on the P100Plug class instances, it raises an exception on the handshake; i confirmed this error with this simple test code:

```
# Setup connection with devices/cloud
p100 = PyP100.P100(ipAddress, email, password)

try:
    p100.handshake()
    p100.login()
    data = p100.getDeviceInfo()

    encodedName = data["result"]["nickname"]
    name = b64decode(encodedName)
    print(name)
    p100.handshake()  """this line throws an exception"""
    p100.login()
except Exception as e:
    print("Could not connect to plug. Possibly invalid credentials::{}".format(str(e)))
```

the error is raised on the second handshake; the PyP100, on the handshake method, tries to recover the result;

`encryptedKey = r.json()["result"]["key"]`

but the result subindex does not exists; the response is

`{'error_code': 9999}`

i've managed to get it working modifying the update method, adding a try-catch on both methods (handshake and login). It seems that the second handshake-login invocation raises an error for some reason (i don't know if its a problem of timing, or something related with a new firmware)

anyway, it seems that those invocations are not needed for the tapo p100 in order to work (i've tested it and the switches works like a charm, even throwing both exceptions)

   ```
 def update(self):
        try:
            self._p100.handshake()
        except Exception as e:
            _LOGGER.error("handshake error:{}".format(str(e)))

        try:
            self._p100.login()
        except Exception as e:
            _LOGGER.error("login error:{}".format(str(e)))

        data = self._p100.getDeviceInfo()

        encoded_name = data["result"]["nickname"]
        name = b64decode(encoded_name)
        self._name = name.decode("utf-8")

        self._is_on = data["result"]["device_on"]
        self._unique_id = data["result"]["device_id"]
```